### PR TITLE
Adding better errors when passing null or undefined to modifiers      - Asserts an error then the function passed to      `did-insert`, `did-update` and `will-destroy`      is not a function.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: install dependencies
         run: yarn install
       - name: lint:js

--- a/addon/modifiers/did-insert.js
+++ b/addon/modifiers/did-insert.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 
 /**
@@ -54,11 +55,16 @@ export default setModifierManager(
       _state,
       element,
       {
-        positional: [fn, ...args],
+        positional: [didInsertFunction, ...args],
         named,
       }
     ) {
-      fn(element, args, named);
+      assert(
+        `You need to pass a function as the first argument to \`did-insert\` you passed ${didInsertFunction}`,
+        typeof didInsertFunction === 'function'
+      );
+
+      didInsertFunction(element, args, named);
     },
 
     updateModifier() {},

--- a/addon/modifiers/did-update.js
+++ b/addon/modifiers/did-update.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 
 /**
@@ -69,9 +70,14 @@ export default setModifierManager(
     },
 
     updateModifier({ element }, args) {
-      let [fn, ...positional] = args.positional;
+      let [didUpdateFunction, ...positional] = args.positional;
 
-      fn(element, positional, args.named);
+      assert(
+        `You need to pass a function as the first argument to \`did-update\` you passed ${didUpdateFunction}`,
+        typeof didUpdateFunction === 'function'
+      );
+
+      didUpdateFunction(element, positional, args.named);
     },
 
     destroyModifier() {},

--- a/addon/modifiers/will-destroy.js
+++ b/addon/modifiers/will-destroy.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 
 /**
@@ -53,9 +54,14 @@ export default setModifierManager(
     updateModifier() {},
 
     destroyModifier({ element }, args) {
-      let [fn, ...positional] = args.positional;
+      let [willDestroyFunction, ...positional] = args.positional;
 
-      fn(element, positional, args.named);
+      assert(
+        `You need to pass a function as the first argument to \`will-destroy\` you passed ${willDestroyFunction}`,
+        typeof willDestroyFunction === 'function'
+      );
+
+      willDestroyFunction(element, positional, args.named);
     },
   }),
   class WillDestroyModifier {}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.10.0",
-    "ember-modifier-manager-polyfill": "^1.1.0"
+    "ember-modifier-manager-polyfill": "^1.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/tests/integration/modifiers/did-insert-test.js
+++ b/tests/integration/modifiers/did-insert-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Component from '@ember/component';
 
@@ -75,5 +75,20 @@ module('Integration | Modifier | did-insert', function(hooks) {
     await render(hbs`{{sometimes-fades-in shouldShow=true}}`);
 
     assert.dom('.alert').hasClass('fade-in');
+  });
+
+  test('throws meaningful error when did-insert does not receive a function', async function(assert) {
+    assert.expect(1);
+
+    this.notAFunction = null;
+
+    setupOnerror(function(error) {
+      assert.equal(
+        error.message,
+        'Assertion Failed: You need to pass a function as the first argument to `did-insert` you passed null'
+      );
+    });
+
+    await render(hbs`<div {{did-insert this.notAFunction}}></div>`);
   });
 });

--- a/tests/integration/modifiers/did-update-test.js
+++ b/tests/integration/modifiers/did-update-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | did-update', function(hooks) {
@@ -22,6 +22,23 @@ module('Integration | Modifier | did-update', function(hooks) {
       hbs`<div data-foo="some-thing" {{did-update this.someMethod this.boundValue}}></div>`
     );
 
+    this.set('boundValue', 'update');
+  });
+
+  test('throws meaningful error when did-update does not receive a function', async function(assert) {
+    assert.expect(1);
+
+    this.notAFunction = null;
+    this.set('boundValue', 'initial');
+
+    setupOnerror(function(error) {
+      assert.equal(
+        error.message,
+        'Assertion Failed: You need to pass a function as the first argument to `did-update` you passed null'
+      );
+    });
+
+    await render(hbs`<div {{did-update this.notAFunction this.boundValue}}></div>`);
     this.set('boundValue', 'update');
   });
 });

--- a/tests/integration/modifiers/will-destroy-test.js
+++ b/tests/integration/modifiers/will-destroy-test.js
@@ -45,8 +45,6 @@ module('Integration | Modifier | will-destroy', function(hooks) {
   });
 
   test('throws meaningful error when will-destroy does not receive a function', async function(assert) {
-    assert.expect(2);
-
     this.notAFunction = null;
     this.set('show', true);
 

--- a/tests/integration/modifiers/will-destroy-test.js
+++ b/tests/integration/modifiers/will-destroy-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | will-destroy', function(hooks) {
@@ -39,6 +39,25 @@ module('Integration | Modifier | will-destroy', function(hooks) {
     await render(
       hbs`{{#if show}}<div data-foo="some-thing" {{will-destroy this.someMethod "some-positional-value" some="hash-value"}}></div>{{/if}}`
     );
+
+    // trigger destroy
+    this.set('show', false);
+  });
+
+  test('throws meaningful error when will-destroy does not receive a function', async function(assert) {
+    assert.expect(2);
+
+    this.notAFunction = null;
+    this.set('show', true);
+
+    setupOnerror(function(error) {
+      assert.equal(
+        error.message,
+        'Assertion Failed: You need to pass a function as the first argument to `will-destroy` you passed null'
+      );
+    });
+
+    await render(hbs`{{#if show}}<div {{will-destroy this.notAFunction}}></div>{{/if}}`);
 
     // trigger destroy
     this.set('show', false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,7 +3699,7 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modifier-manager-polyfill@^1.1.0:
+ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3700,9 +3700,9 @@ ember-maybe-import-regenerator@^0.1.6:
     regenerator-runtime "^0.9.5"
 
 ember-modifier-manager-polyfill@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.1.0.tgz#06397b05a3f9a5868b05fca11fe10c7f6b78a328"
-  integrity sha512-fCEumUwdAnwk8rGSEww1/NkIHbmLOS8kRmEZyO9mxeIy+BtdYqdSIMrn3tSnt9QeacWQm2zdR8KXBqc2bc1G6A==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
+  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
   dependencies:
     ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"


### PR DESCRIPTION
     - Today the error is `fn must be a function`;
     `fn` has another meaning in emberland.